### PR TITLE
Add links to CHPC_Access

### DIFF
--- a/Computation/CHPC_Access.md
+++ b/Computation/CHPC_Access.md
@@ -9,4 +9,4 @@ Notes:
 1. Files are mounted read only to protect the integrity of the data on the CNDA. Mechanisms exist to programatically write results back to your CNDA project.
 2. Send an email to support@rcif.wustl.edu to request this service. There is no fee involved.
 3. The CHPC has both free and subscription services.
-Find out more about the charges by sending an email to support@rcif.wustl.edu.
+Find out more about the charges at the [CHPC Accounting FAQs](https://docs.chpc.wustl.edu/rates/), or you can contact support@rcif.wustl.edu with specific questions.


### PR DESCRIPTION
This adds links to the CHPC access page. This is separate, since it seems redundant to the other file. Should this be removed?